### PR TITLE
Fix compilation errors on new Vala

### DIFF
--- a/src/Services/DBusInterfaces/Device.vala
+++ b/src/Services/DBusInterfaces/Device.vala
@@ -56,7 +56,7 @@ namespace Power.Services.DBusInterfaces {
         public abstract double energy_rate { public get; public set; }
         public abstract double luminosity { public get; public set; }
         public abstract double percentage { public get; public set; }
-        public abstract double temperature { public  get; public set; }
+        public abstract double temperature { public get; public set; }
         public abstract double voltage { public get; public set; }
         public abstract int64 time_to_empty { public get; public set; }
         public abstract int64 time_to_full { public get; public set; }

--- a/src/Services/DBusInterfaces/Device.vala
+++ b/src/Services/DBusInterfaces/Device.vala
@@ -42,32 +42,32 @@ namespace Power.Services.DBusInterfaces {
         public abstract StatisticsDataPoint[] get_statistics (string type) throws GLib.Error;
         public abstract void refresh () throws GLib.Error;
 
-        public abstract bool has_history { public owned get; public set; }
-        public abstract bool has_statistics { public owned get; public set; }
-        public abstract bool is_present { public owned get; public set; }
-        public abstract bool is_rechargeable { public owned get; public set; }
-        public abstract bool online { public owned get; public set; }
-        public abstract bool power_supply { public owned get; public set; }
-        public abstract double capacity { public owned get; public set; }
-        public abstract double energy { public owned get; public set; }
-        public abstract double energy_empty { public owned get; public set; }
-        public abstract double energy_full { public owned get; public set; }
-        public abstract double energy_full_design { public owned get; public set; }
-        public abstract double energy_rate { public owned get; public set; }
-        public abstract double luminosity { public owned get; public set; }
-        public abstract double percentage { public owned get; public set; }
-        public abstract double temperature { public owned get; public set; }
-        public abstract double voltage { public owned get; public set; }
-        public abstract int64 time_to_empty { public owned get; public set; }
-        public abstract int64 time_to_full { public owned get; public set; }
+        public abstract bool has_history { public get; public set; }
+        public abstract bool has_statistics { public get; public set; }
+        public abstract bool is_present { public get; public set; }
+        public abstract bool is_rechargeable { public get; public set; }
+        public abstract bool online { public get; public set; }
+        public abstract bool power_supply { public get; public set; }
+        public abstract double capacity { public get; public set; }
+        public abstract double energy { public get; public set; }
+        public abstract double energy_empty { public get; public set; }
+        public abstract double energy_full { public get; public set; }
+        public abstract double energy_full_design { public get; public set; }
+        public abstract double energy_rate { public get; public set; }
+        public abstract double luminosity { public get; public set; }
+        public abstract double percentage { public get; public set; }
+        public abstract double temperature { public  get; public set; }
+        public abstract double voltage { public get; public set; }
+        public abstract int64 time_to_empty { public get; public set; }
+        public abstract int64 time_to_full { public get; public set; }
         public abstract string model { public owned get; public set; }
         public abstract string native_path { public owned get; public set; }
         public abstract string serial { public owned get; public set; }
         public abstract string vendor { public owned get; public set; }
-        public abstract uint32 battery_level { owned get; }
-        public abstract uint32 state { public owned get; public set; }
-        public abstract uint32 technology { public owned get; public set; }
-        public abstract uint32 Type { public owned get; public set; }
-        public abstract uint64 update_time { public owned get; public set; }
+        public abstract uint32 battery_level { get; }
+        public abstract uint32 state { public get; public set; }
+        public abstract uint32 technology { public get; public set; }
+        public abstract uint32 Type { public get; public set; }
+        public abstract uint64 update_time { public get; public set; }
     }
 }


### PR DESCRIPTION
```
../src/Services/DBusInterfaces/Device.vala:45:44-45:60: error: `owned' accessor not allowed for specified property type
   45 |         public abstract bool has_history { public owned get; public set; }
      |                                            ^~~~~~~~~~~~~~~~~              
../src/Services/DBusInterfaces/Device.vala:46:47-46:63: error: `owned' accessor not allowed for specified property type
   46 |         public abstract bool has_statistics { public owned get; public set; }
      |                                               ^~~~~~~~~~~~~~~~~              
../src/Services/DBusInterfaces/Device.vala:47:43-47:59: error: `owned' accessor not allowed for specified property type
   47 |         public abstract bool is_present { public owned get; public set; }
      |                                           ^~~~~~~~~~~~~~~~~              
../src/Services/DBusInterfaces/Device.vala:48:48-48:64: error: `owned' accessor not allowed for specified property type
   48 |         public abstract bool is_rechargeable { public owned get; public set; }
      |                                                ^~~~~~~~~~~~~~~~~              
../src/Services/DBusInterfaces/Device.vala:49:39-49:55: error: `owned' accessor not allowed for specified property type
   49 |         public abstract bool online { public owned get; public set; }
      |                                       ^~~~~~~~~~~~~~~~~              
../src/Services/DBusInterfaces/Device.vala:50:45-50:61: error: `owned' accessor not allowed for specified property type
   50 |         public abstract bool power_supply { public owned get; public set; }
      |                                             ^~~~~~~~~~~~~~~~~              
../src/Services/DBusInterfaces/Device.vala:51:43-51:59: error: `owned' accessor not allowed for specified property type
   51 |         public abstract double capacity { public owned get; public set; }
      |                                           ^~~~~~~~~~~~~~~~~              
../src/Services/DBusInterfaces/Device.vala:52:41-52:57: error: `owned' accessor not allowed for specified property type
   52 |         public abstract double energy { public owned get; public set; }
      |                                         ^~~~~~~~~~~~~~~~~              
../src/Services/DBusInterfaces/Device.vala:53:47-53:63: error: `owned' accessor not allowed for specified property type
   53 |         public abstract double energy_empty { public owned get; public set; }
      |                                               ^~~~~~~~~~~~~~~~~              
../src/Services/DBusInterfaces/Device.vala:54:46-54:62: error: `owned' accessor not allowed for specified property type
   54 |         public abstract double energy_full { public owned get; public set; }
      |                                              ^~~~~~~~~~~~~~~~~              
../src/Services/DBusInterfaces/Device.vala:55:53-55:69: error: `owned' accessor not allowed for specified property type
   55 |         public abstract double energy_full_design { public owned get; public set; }
      |                                                     ^~~~~~~~~~~~~~~~~              
../src/Services/DBusInterfaces/Device.vala:56:46-56:62: error: `owned' accessor not allowed for specified property type
   56 |         public abstract double energy_rate { public owned get; public set; }
      |                                              ^~~~~~~~~~~~~~~~~              
../src/Services/DBusInterfaces/Device.vala:57:45-57:61: error: `owned' accessor not allowed for specified property type
   57 |         public abstract double luminosity { public owned get; public set; }
      |                                             ^~~~~~~~~~~~~~~~~              
../src/Services/DBusInterfaces/Device.vala:58:45-58:61: error: `owned' accessor not allowed for specified property type
   58 |         public abstract double percentage { public owned get; public set; }
      |                                             ^~~~~~~~~~~~~~~~~              
../src/Services/DBusInterfaces/Device.vala:59:46-59:62: error: `owned' accessor not allowed for specified property type
   59 |         public abstract double temperature { public owned get; public set; }
      |                                              ^~~~~~~~~~~~~~~~~              
../src/Services/DBusInterfaces/Device.vala:60:42-60:58: error: `owned' accessor not allowed for specified property type
   60 |         public abstract double voltage { public owned get; public set; }
      |                                          ^~~~~~~~~~~~~~~~~              
../src/Services/DBusInterfaces/Device.vala:61:47-61:63: error: `owned' accessor not allowed for specified property type
   61 |         public abstract int64 time_to_empty { public owned get; public set; }
      |                                               ^~~~~~~~~~~~~~~~~              
../src/Services/DBusInterfaces/Device.vala:62:46-62:62: error: `owned' accessor not allowed for specified property type
   62 |         public abstract int64 time_to_full { public owned get; public set; }
      |                                              ^~~~~~~~~~~~~~~~~              
../src/Services/DBusInterfaces/Device.vala:67:48-67:57: error: `owned' accessor not allowed for specified property type
   67 |         public abstract uint32 battery_level { owned get; }
      |                                                ^~~~~~~~~~  
../src/Services/DBusInterfaces/Device.vala:68:40-68:56: error: `owned' accessor not allowed for specified property type
   68 |         public abstract uint32 state { public owned get; public set; }
      |                                        ^~~~~~~~~~~~~~~~~              
../src/Services/DBusInterfaces/Device.vala:69:45-69:61: error: `owned' accessor not allowed for specified property type
   69 |         public abstract uint32 technology { public owned get; public set; }
      |                                             ^~~~~~~~~~~~~~~~~              
../src/Services/DBusInterfaces/Device.vala:70:39-70:55: error: `owned' accessor not allowed for specified property type
   70 |         public abstract uint32 Type { public owned get; public set; }
      |                                       ^~~~~~~~~~~~~~~~~              
../src/Services/DBusInterfaces/Device.vala:71:46-71:62: error: `owned' accessor not allowed for specified property type
   71 |         public abstract uint64 update_time { public owned get; public set; }
      |                                              ^~~~~~~~~~~~~~~~~              
Compilation failed: 23 error(s), 3 warning(s)
```